### PR TITLE
using custom wire pins, useful for esp-based boads

### DIFF
--- a/NDIR_I2C/NDIR_I2C.cpp
+++ b/NDIR_I2C/NDIR_I2C.cpp
@@ -258,7 +258,6 @@ uint8_t NDIR_I2C::receive(uint8_t *pbuf, uint8_t n) {
 
 uint8_t NDIR_I2C::read_register(uint8_t reg_addr, uint8_t *pval)
 {
-    uint8_t result;
 
     WIRE.beginTransmission(i2c_addr);
     WIRE.write(reg_addr << 3);
@@ -278,7 +277,6 @@ uint8_t NDIR_I2C::read_register(uint8_t reg_addr, uint8_t *pval)
 
 uint8_t NDIR_I2C::write_register(uint8_t reg_addr, uint8_t *pdata, uint8_t n)
 {
-    uint8_t result;
 
     WIRE.beginTransmission(i2c_addr);
     WIRE.write(reg_addr << 3);

--- a/NDIR_I2C/NDIR_I2C.cpp
+++ b/NDIR_I2C/NDIR_I2C.cpp
@@ -71,6 +71,10 @@ uint8_t NDIR_I2C::cmd_calibrateZero[9]          = {0xFF,0x01,0x87,0x00,0x00,0x00
 uint8_t NDIR_I2C::cmd_enableAutoCalibration[9]  = {0xFF,0x01,0x79,0xA0,0x00,0x00,0x00,0x00,0xE6};
 uint8_t NDIR_I2C::cmd_disableAutoCalibration[9] = {0xFF,0x01,0x79,0x00,0x00,0x00,0x00,0x00,0x86};
 
+#define UNSET 254
+uint8_t customSda = UNSET;
+uint8_t customScl = UNSET;
+
 NDIR_I2C::NDIR_I2C(uint8_t i2c_addr)
 {
     if (i2c_addr >= 8 && i2c_addr < 120) {
@@ -80,11 +84,20 @@ NDIR_I2C::NDIR_I2C(uint8_t i2c_addr)
     }
 }
 
+uint8_t NDIR_I2C::setCustomWirePorts(uint8_t sda, uint8_t scl) {
+    customSda = sda;
+    customScl = scl;
+}
 
 uint8_t NDIR_I2C::begin()
 {
     if (i2c_addr) {
-        WIRE.begin();
+        if(customSda == UNSET || customScl == UNSET) {
+            WIRE.begin();
+        } else {
+            WIRE.begin(customSda, customScl);
+        }
+
         write_register(IOCONTROL, 0x08);
 
         if (write_register(FCR, 0x07)) {

--- a/NDIR_I2C/NDIR_I2C.cpp
+++ b/NDIR_I2C/NDIR_I2C.cpp
@@ -84,7 +84,7 @@ NDIR_I2C::NDIR_I2C(uint8_t i2c_addr)
     }
 }
 
-uint8_t NDIR_I2C::setCustomWirePorts(uint8_t sda, uint8_t scl) {
+void NDIR_I2C::setCustomWirePorts(uint8_t sda, uint8_t scl) {
     customSda = sda;
     customScl = scl;
 }

--- a/NDIR_I2C/NDIR_I2C.h
+++ b/NDIR_I2C/NDIR_I2C.h
@@ -30,7 +30,7 @@ class NDIR_I2C {
         uint32_t ppm;
 
         uint8_t  begin();
-            uint8_t  setCustomWirePorts(uint8_t sda, uint8_t scl);
+        void  setCustomWirePorts(uint8_t sda, uint8_t scl);
         uint8_t  measure();
         uint8_t  reset();
         void     calibrateZero();

--- a/NDIR_I2C/NDIR_I2C.h
+++ b/NDIR_I2C/NDIR_I2C.h
@@ -30,6 +30,7 @@ class NDIR_I2C {
         uint32_t ppm;
 
         uint8_t  begin();
+            uint8_t  setCustomWirePorts(uint8_t sda, uint8_t scl);
         uint8_t  measure();
         uint8_t  reset();
         void     calibrateZero();

--- a/NDIR_I2C/examples/ReadConcentration/ReadConcentration.ino
+++ b/NDIR_I2C/examples/ReadConcentration/ReadConcentration.ino
@@ -7,6 +7,9 @@ void setup()
 {
     Serial.begin(9600);
 
+    //if working with esp-based boards, set which pins you're using (in this case SDA is D2, SCL is D3)
+    //mySensor.setCustomWirePins(D2, D3);
+
     if (mySensor.begin()) {
         Serial.println("Wait 10 seconds for sensor initialization...");
         delay(10000);


### PR DESCRIPTION
For esp-based boards, wire.begin(sda, scl) should be called, otherwise i2c is not working.

https://github.com/esp8266/Arduino

So I've added a method, which can help update the sda and scl pins before begin() is called.